### PR TITLE
Update page.js

### DIFF
--- a/common/js/page.js
+++ b/common/js/page.js
@@ -17,7 +17,7 @@ $(function() {
     var t = $(this);
     var code = t.text();
     t.html("&#x" + code + ";");
-    t.attr("href", "http://unicode-table.com/en/" + code + "/");
+    t.attr("href", "https://symbl.cc/en/" + code + "/");
     t.attr("target", "_blank");
   });
 });


### PR DESCRIPTION
This URL http://unicode-table.com/ has changed to https://symbl.cc/ Obviously, this file is responsible for displaying the URL to the page wiki/blog/2015/1129-unicode-general-category-number.html Since unicode-table.com no longer exists, please accept the changes to the page.js file